### PR TITLE
feat: add nvim-lsp-file-operations plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2113,6 +2113,13 @@
             "shorthand": "visual-whitespace.nvim",
             "summary": "A Neovim plugin to reveal whitespace characters in visual mode, like VSCode",
             "license": "UNKNOWN"
+        },
+        {
+            "name": "antosha417/nvim-lsp-file-operations",
+            "shorthand": "nvim-lsp-file-operations",
+            "dependencies": ["plenary.nvim"],
+            "summary": "Neovim plugin that adds support for file operations using built-in LSP",
+            "license": "Apache-2.0"
         }
     ]
 }


### PR DESCRIPTION
The project's readme reads:

> Neovim plugin that adds support for file operations using built-in LSP
>
> nvim-lsp-file-operations is a Neovim plugin that adds support for file
> operations using built-in LSP support. This plugin works by
> subscribing to events emitted by nvim-tree and neo-tree. But other
> integrations are possible.
>
> https://github.com/antosha417/nvim-lsp-file-operations

Note that while the project's readme specifies other dependencies besides plenary.nvim, it seems they are actually optional and not strictly required.

I'm working on adding a new integration to this project from my own project to help achieve a more stable LSP integration (https://github.com/mikavilpas/yazi.nvim/issues/80). Since I added luarocks support to my project a while ago, I would love to be able to support users preferring luarocks for their plugin management.