### PR TITLE
ci: set name of the job

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -12,6 +12,7 @@ jobs:
       max-parallel: 10 # Don't DDOS the luarocks servers
       matrix:
         plugin: ${{ github.event.client_payload.plugins }}
+    name: Pushing ${{ matrix.plugin.shorthand }}
 
     steps:
       - name: Checkout plugin repository


### PR DESCRIPTION
because looking at ![image](https://github.com/user-attachments/assets/91a765c9-8100-4a3f-8641-c0b896eb93e2) it's hard to know which plugin is being uploaded
