### PR TITLE
fix: correct name of neotest-zig

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2102,7 +2102,7 @@
             "license": "MIT"
         },
         {
-            "name": "lawrence-laz/neotest-zig/",
+            "name": "lawrence-laz/neotest-zig",
             "shorthand": "neotest-zig",
             "dependencies": ["neotest", "plenary.nvim", "tree-sitter-zig"],
             "summary": "Test runner for Zig in Neovim using Neotest backend.",


### PR DESCRIPTION
A trailing slash accidentally slipped in.