### PR TITLE
ci: attempt to test added plugins

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,20 +4,58 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
+  # computes what plugins to test against
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      plugins: ${{ steps.json.outputs.plugins }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+      - run: nix profile install nixpkgs#python3Packages.jsondiff
+      - name: build matrix of plugins to test
+        id: json
+        run: |
+
+          git fetch origin ${{github.base_ref}}
+          git show origin/${{github.base_ref}}:plugins.json > plugins-old.json
+
+          echo "testing diff.json"
+          jdiff plugins-old.json plugins.json > diff.json
+
+          jq '.plugins."$insert"[][1]' diff.json > ./new.json
+
+          echo "New plugins added in this PR:"
+          cat new.json
+
+          # always run the tests for the first available plugin
+          jq .plugins[0] plugins.json > first.json
+
+          # concatenate the new plugins with the first one
+          jq -s . new.json first.json > matrix.json
+
+          # for debug
+          echo "cat matrix.json"
+          cat matrix.json
+
+          echo "plugins=$(jq -c . < ./matrix.json)" >> $GITHUB_OUTPUT
+
+  test-generated-matrix:
+    runs-on: ubuntu-latest
+    needs: [ prepare ]
+    steps:
+    - name: test generated matrix
+      run: |
+        echo "Hello world"
+        echo '${{ toJSON(needs.prepare.outputs) }}'
+        echo ${{ needs.prepare.outputs.plugins }}
+
   test-pr:
     runs-on: ubuntu-latest
+    needs: [ prepare ]
     strategy:
       matrix:
-        plugin: [
-          {
-              "name": "startup-nvim/startup.nvim",
-              "shorthand": "startup.nvim",
-              "license": "GPL-2.0",
-              "summary": "A highly configurable neovim startup screen",
-              "dependencies": ["telescope.nvim", "plenary.nvim"]
-          }
-        ]
-
+        plugin: ${{ fromJSON(needs.prepare.outputs.plugins) }}
     steps:
     - name: Install Lua
       if: ${{ env.RELEASE_VERSION != '' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,10 +25,6 @@ jobs:
       with:
         luaVersion: "5.1"
 
-    - name: test concat
-      run: |
-        echo ${{ join (matrix.deps, '\n')}}
-
     - name: Checkout plugin repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -27,7 +27,7 @@ jobs:
         uses: rlalik/setup-cpp-compiler@master
         with:
           compiler: clang-latest
-          
+
       - name: Checkout plugin repository
         uses: actions/checkout@v4
         with:
@@ -51,7 +51,7 @@ jobs:
 
       - name: Get resources
         uses: actions/checkout@v4
-        with: 
+        with:
           sparse-checkout: |
             resources
           path: nurr

--- a/plugins.json
+++ b/plugins.json
@@ -92,6 +92,13 @@
             "license": "MIT"
         },
         {
+            "name": "leath-dub/snipe.nvim",
+            "shorthand": "snipe.nvim",
+            "dependencies": [],
+            "summary": "Efficient targetted menu built for fast buffer navigation",
+            "license": "UNKNOWN"
+        },
+        {
             "name": "nacro90/numb.nvim",
             "shorthand": "numb.nvim",
             "dependencies": [],


### PR DESCRIPTION
On PRs, we always test against the same hardcoded plugin startup.nvim. 

Ideally we would feed the tests with the added plugin and a reference one .
This is an attempt to dynamically build the matrix from a diff of the plugins.json (inspired by https://www.kenmuse.com/blog/dynamic-build-matrices-in-github-actions/), then I will test it against 
https://github.com/nvim-neorocks/nurr/pull/33 