### PR TITLE
feat: better git tag -> version fetching

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake . -Lv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,20 +39,7 @@ jobs:
         id: get-release
         run: |
           # Check for semver tags
-          TAGS="$(git for-each-ref --sort=authordate --format '%(refname)' refs/tags )"
-          if [[ -n "$TAGS" ]]; then
-            echo "Found tags:"
-            echo "$TAGS"
-          fi
-          TAG="$(git for-each-ref --sort=authordate --format '%(refname)' refs/tags | sed 's/refs\/tags\/\(.*\)/\1/' | grep -P '^[v]*[0-9]{1,}.[0-9]{1,}.[0-9]{1,}' | tail -n1)"
-          if [[ -z "$TAG" ]]; then
-            # Try without patch
-            TAG="$(git for-each-ref --sort=authordate --format '%(refname)' refs/tags | sed 's/refs\/tags\/\(.*\)/\1/' | grep -P '^[v]*[0-9]{1,}.[0-9]{1,}' | tail -n1)"
-          fi
-          if [[ -z "$TAG" ]]; then
-            # Try without minor
-            TAG="$(git for-each-ref --sort=authordate --format '%(refname)' refs/tags | sed 's/refs\/tags\/\(.*\)/\1/' | grep -P '^[v]*[0-9]{1,}' | tail -n1)"
-          fi
+          TAG="$(./scripts/echo_latest_tag_version.lua)"
           if [[ -n "$TAG" ]]; then
             echo "Found $TAG"
             git checkout $TAG

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 chunks.json
+.luarc.json
+.direnv

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,12 @@
+globals = {
+    "_",
+    "vim",
+    "describe",
+    "it",
+    "assert",
+    "stub",
+}
+
+ignore = {
+    "631", -- max_line_length
+}

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,1 @@
+/nix/store/d7najw0l2kxnh56ki6myk5yvqdjj5cml-luarc.json

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,124 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "gen-luarc": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1718922730,
+        "narHash": "sha256-ykhhOPqA9NzdNBr3ii+3h2DkK2+wasNqQLfMF6BXxTE=",
+        "owner": "mrcjkb",
+        "repo": "nix-gen-luarc-json",
+        "rev": "021e8078e43884c6cdc70ca753d9a0b146cd55a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mrcjkb",
+        "repo": "nix-gen-luarc-json",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1718714799,
+        "narHash": "sha256-FUZpz9rg3gL8NVPKbqU8ei1VkPLsTIfAJ2fdAf5qjak=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c00d587b1a1afbf200b1d8f0b0e4ba9deb1c7f0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1717284937,
+        "narHash": "sha256-lIbdfCsf8LMFloheeE6N31+BMIeixqyQWbSr2vk79EQ=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/eb9ceca17df2ea50a250b6b27f7bf6ab0186f198.tar.gz"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1718983919,
+        "narHash": "sha256-+1xgeIow4gJeiwo4ETvMRvWoircnvb0JOt7NS9kUhoM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "90338afd6177fc683a04d934199d693708c85a3b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "gen-luarc": "gen-luarc",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "devShell for Neovim Lua plugins";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    gen-luarc.url = "github:mrcjkb/nix-gen-luarc-json";
+  };
+
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    flake-parts,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            inputs.gen-luarc.overlays.default
+          ];
+        };
+        luarc = pkgs.mk-luarc {
+          nvim = pkgs.neovim-nightly;
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          name = "NURR devShell";
+          shellHook = ''
+            ln -fs ${pkgs.luarc-to-json luarc} .luarc.json
+          '';
+          buildInputs = with pkgs; [
+            lua-language-server
+            stylua
+            (lua5_1.withPackages (luaPkgs:
+              with luaPkgs; [
+                luarocks
+                luacheck
+              ]))
+          ];
+        };
+      };
+    };
+}

--- a/scripts/echo_latest_tag_version.lua
+++ b/scripts/echo_latest_tag_version.lua
@@ -1,0 +1,89 @@
+#!/usr/bin/env -S nvim -u NONE -U NONE -N -i NONE -l
+
+-- Copied over from rocks-git.nvim
+
+---@param rev string?
+---@return boolean
+local function is_version(rev)
+	if not rev then
+		return false
+	end
+	if tonumber(rev) then
+		return true
+	end
+	local version_str = rev:gsub("v", "")
+	return vim.iter(vim.gsplit(version_str, ".", { plain = true })):all(function(str)
+		return tonumber(str) ~= nil
+	end)
+end
+
+---@param rev string?
+---@return vim.Version?
+local function get_version(rev)
+	if not is_version(rev) then
+		return
+	end
+	local ok, version = pcall(vim.version.parse, rev)
+	return ok and version or nil
+end
+
+---@param stdout string
+---@return string | nil
+local function parse_git_latest_semver_tag(stdout)
+	local latest_tag = nil
+	local latest_version = nil
+	for tag in stdout:gmatch("refs/tags/([^\n]+)") do
+		local version = get_version(tag)
+		if version and latest_version then
+			if version > latest_version then
+				latest_tag = tag
+				latest_version = version
+			end
+		elseif version then
+			latest_tag = tag
+			latest_version = version
+		end
+	end
+	return latest_tag
+end
+
+---@param args string[] git CLI arguments
+---@param on_exit fun(sc: vim.SystemCompleted)|nil Called asynchronously when the git command exits.
+---@param opts? vim.SystemOpts
+---@return vim.SystemObj | nil
+---@see vim.system
+local function git_cli(args, on_exit, opts)
+	opts = opts or {}
+	local git_cmd = vim.list_extend({
+		"git",
+	}, args)
+	---@type boolean, vim.SystemObj | string
+	local ok, so_or_err = pcall(vim.system, git_cmd, opts, on_exit)
+	if ok then
+		---@cast so_or_err vim.SystemObj
+		return so_or_err
+	else
+		---@cast so_or_err string
+		---@type vim.SystemCompleted
+		local sc = {
+			code = 1,
+			signal = 0,
+			stderr = ("Failed to invoke git: %s"):format(so_or_err),
+		}
+		if on_exit then
+			on_exit(sc)
+		end
+	end
+end
+
+local function echo_latest_git_tag()
+	local sc = git_cli({ "for-each-ref", "--format", "%(refname)", "refs/tags" }):wait()
+	if sc.code == 0 and sc.stdout then
+		local latest_tag, _ = parse_git_latest_semver_tag(sc.stdout or "")
+		if latest_tag then
+			io.write(latest_tag)
+		end
+	end
+end
+
+echo_latest_git_tag()


### PR DESCRIPTION
Replaces the bash hell we have to detect tags (which apparently doesn't work on tags that were published using GitHub releases) with a script that uses the logic from rocks-git.nvim.