### PR TITLE
{lualine.nvim,trouble.nvim}: remove optional nvim-web-devicons dependency

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -59,7 +59,7 @@
         {
             "name": "folke/trouble.nvim",
             "shorthand": "trouble.nvim",
-            "dependencies": ["nvim-web-devicons"],
+            "dependencies": [],
             "summary": "A pretty diagnostics, references, telescope results, quickfix and location list to help you solve all the trouble your code is causing",
             "license": "Apache-2.0"
         },

--- a/plugins.json
+++ b/plugins.json
@@ -1440,7 +1440,7 @@
             "shorthand": "lualine.nvim",
             "license": "MIT",
             "summary": "A blazing fast and easy to configure neovim statusline plugin written in pure lua.",
-            "dependencies": ["nvim-web-devicons"]
+            "dependencies": []
         },
         {
             "name": "rktjmp/lush.nvim",


### PR DESCRIPTION
> Plug 'nvim-lualine/lualine.nvim'
> " If you want to have icons in your statusline choose one of these
> Plug 'nvim-tree/nvim-web-devicons'

From lualine.nvim’s docs, it is clear this is an optional dependency. In fact, you need to explicitly enable icons in the config.

> nvim-web-devicons is optional to enable file icons

From trouble.nvim’s docs

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.