### PR TITLE
ref: use catgoose's fork of nvim-colorizer.lua

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2285,7 +2285,7 @@
             "license": "MIT"
         },
         {
-            "name": "norcalli/nvim-colorizer.lua",
+            "name": "catgoose/nvim-colorizer.lua",
             "shorthand": "nvim-colorizer.lua",
             "dependencies": [],
             "summary": "The fastest Neovim colorizer.",


### PR DESCRIPTION
norcalli's repository has not been updated in a while now (only 1 commit in 4 years). Catgoose is now maintaining a fork which is already +100 commits ahead, and contains a lot of fixes and new features.