### PR TITLE
fix: remove grug-far.nvim

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -148,13 +148,6 @@
             "license": "GPL-3.0"
         },
         {
-            "name": "MagicDuck/grug-far.nvim",
-            "shorthand": "grug-far.nvim",
-            "dependencies": [],
-            "summary": "Find And Replace plugin for neovim.",
-            "license": "MIT"
-        },
-        {
             "name": "dstein64/vim-startuptime",
             "shorthand": "vim-startuptime",
             "dependencies": [],


### PR DESCRIPTION
upstream itself is running luarocks-tag-release see https://github.com/MagicDuck/grug-far.nvim/pull/392