### PR TITLE
oil.nvim: remove optional nvim-web-devicons dependency

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -73,7 +73,7 @@
         {
             "name": "stevearc/oil.nvim",
             "shorthand": "oil.nvim",
-            "dependencies": ["nvim-web-devicons"],
+            "dependencies": [],
             "summary": "Neovim file explorer: edit your filesystem like a buffer",
             "license": "MIT"
         },


### PR DESCRIPTION
`nvim-web-devicons` is an optional dependency.

`mini.icon` is also supported as an alternative icon provider.

If neither is present, the plug-in simply does not display any icons.