### PR TITLE
Add kulala-http tree-sitter parser

### DIFF
--- a/tree-sitter-parsers.json
+++ b/tree-sitter-parsers.json
@@ -1034,6 +1034,15 @@
     },
     {
       "install_info": {
+        "location": "lua/tree-sitter",
+        "revision": "0d50e9ce5c992fe507743d8641b36125e668aad4",
+        "url": "https://github.com/mistweaverco/kulala.nvim"
+      },
+      "lang": "kulala_http",
+      "tier": 2
+    },
+    {
+      "install_info": {
         "revision": "597efbd7ce9a814bb058f48eabd055b1d1e12145",
         "url": "https://github.com/pfeiferj/tree-sitter-hurl"
       },


### PR DESCRIPTION
I've tried out [kulala.nvim](https://github.com/mistweaverco/kulala.nvim) and noticed that the grammar it expects is not available in nix.

Noteworthy is that the grammar needs a custom location: `lua/tree-sitter`

To test this, I have done the following steps:

1. pointed the update-script in nixpkgs to the file of this PR: https://github.com/saep/nixpkgs/commit/2e568b33ac00ba2bde850c5539d0feb9d8164b35
2. ran the update script: https://github.com/saep/nixpkgs/commit/d78ff5864bbea1209603779c259956c13d211a29
3. rebuild my system 
4. opened an `.http` file and the file was highlighted properly and there was no longer an error message
5. `:checkhealth nvim-treesitter` now lists `kulala_http`
