### PR TITLE
refer to the nurr project in detailed_description

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,6 +94,9 @@ jobs:
         version: "scm"
         summary: ${{ matrix.plugin.summary }}
         license: ${{ matrix.plugin.license }}
+        detailed_description: |
+          ${{ matrix.plugin.detailed_description }}
+          Uploaded by the [NURR](https://github.com/lumen-oss/nurr/) project
         labels: neovim
         copy_directories: |
           {{ neovim.plugin.dirs }}


### PR DESCRIPTION
I would like to add a reference to nurr in the published rockspecs so that users visiting luarocks.org can more easily understand
- package was uploaded by a 3rd-party 
- where/how to contribute

putting as draft with a placeholder, just want to see how it behaves with empty matrix.plugin.detailed_description