### PR TITLE
remove avante: it's now submitted upstream

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -2404,13 +2404,6 @@
             "dependencies": [],
             "summary": "A Lua port of the Everforest colour scheme",
             "license": "MIT"
-        },
-        {
-            "name": "yetone/avante.nvim",
-            "shorthand": "avante.nvim",
-            "dependencies": ["plenary.nvim", "nui.nvim", "nvim-web-devicons"],
-            "summary": "Use your Neovim like using Cursor AI IDE!",
-            "license": "Apache-2.0"
         }
     ]
 }


### PR DESCRIPTION
I've merged the luarocks-tag-release into avante.nvim but the "root" package is owned by nurr. Could anyone remove the nurr avante.nvim from the root manifest https://luarocks.org/modules/neorocks/avante.nvim ?

Once this is done and adter I've checked the upstream release works, this PR could probably be merged ?

I dont know if this explains this error:
https://github.com/yetone/avante.nvim/actions/runs/25194276477/job/73871224490#step:4:541


```

RUNNING: mktemp -d
TEST: luarocks install --tree /home/runner/work/_temp/tmp.516BgFienQ avante.nvim 0.0.28 
RUNNING: luarocks install --tree /home/runner/work/_temp/tmp.516BgFienQ avante.nvim 0.0.28 
luarocks install --tree /home/runner/work/_temp/tmp.516BgFienQ avante.nvim 0.0.28  FAILED
exit code: 256
stdout: 
stderr: 
Error: No results matching query were found for Lua 5.1.
To check if it is available for other Lua versions, use --check-lua-versions.
```