### PR TITLE
tree-sitter: remove some parsers

### DIFF
--- a/tree-sitter-parsers.json
+++ b/tree-sitter-parsers.json
@@ -970,14 +970,6 @@
     },
     {
       "install_info": {
-        "revision": "3bfda9271e3adb08d35f47a2102fe957009e1c55",
-        "url": "https://github.com/Freed-Wu/tree-sitter-hlsplaylist"
-      },
-      "lang": "hlsplaylist",
-      "tier": 2
-    },
-    {
-      "install_info": {
         "revision": "c390f10519ae69fdb03b3e5764f5592fb6924bcc",
         "url": "https://github.com/antosha417/tree-sitter-hocon"
       },
@@ -1454,14 +1446,6 @@
         "url": "https://github.com/artagnon/tree-sitter-mlir"
       },
       "lang": "mlir",
-      "tier": 2
-    },
-    {
-      "install_info": {
-        "revision": "173b0ab53a9c07962c9777189c4c70e90f1c1837",
-        "url": "https://github.com/neomutt/tree-sitter-muttrc"
-      },
-      "lang": "muttrc",
       "tier": 2
     },
     {
@@ -2437,14 +2421,6 @@
     },
     {
       "install_info": {
-        "revision": "75d1b995b0c23400ac8e49db757a2e0386f9fa8f",
-        "url": "https://github.com/Freed-Wu/tree-sitter-tmux"
-      },
-      "lang": "tmux",
-      "tier": 2
-    },
-    {
-      "install_info": {
         "revision": "3937c5cd105ec4127448651a21aef45f52d19609",
         "url": "https://github.com/arnarg/tree-sitter-todotxt"
       },
@@ -2741,14 +2717,6 @@
         "url": "https://github.com/tree-sitter-grammars/tree-sitter-yuck"
       },
       "lang": "yuck",
-      "tier": 2
-    },
-    {
-      "install_info": {
-        "revision": "0554b4a5d313244b7fc000cbb41c04afae4f4e31",
-        "url": "https://github.com/Freed-Wu/tree-sitter-zathurarc"
-      },
-      "lang": "zathurarc",
       "tier": 2
     },
     {


### PR DESCRIPTION
Due to https://github.com/nvim-treesitter/nvim-treesitter/ is archived,
I decide to move the queries from https://github.com/nvim-treesitter/nvim-treesitter/tree/main/runtime/queries
to my repositories for maintenance.

I use https://github.com/lumen-oss/luarocks-build-treesitter-parser/pull/48/
to build the parsers and release them to luarocks.
Can you remove them from https://luarocks.org/modules/neorocks/ ?
